### PR TITLE
Bugfix on time

### DIFF
--- a/reliability_analysis/reliability_analysis.py
+++ b/reliability_analysis/reliability_analysis.py
@@ -111,7 +111,7 @@ def simulate(m, n, r, s, end, lam, mu):
             else:
                 TBF += next_time - t
         # Advance clock
-        t = min(math.ceil(next_time), end)
+        t = min(next_time, end)
     # If the system never failed, TBF and TTF are set to the simulated time span
     if not TBF_history:
         TBF_history.append(end)


### PR DESCRIPTION
Clock was advanced wrong, which weirdly enough worked for (3,3,2,2) but would unravel for larger matrices and give all kinds of weird results